### PR TITLE
Convert Verilog files to UTF-8

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,9 @@
 # 所有文本文件都当做 UTF-8 处理
 * text working-tree-encoding=UTF-8
 
-cpu_top.v   working-tree-encoding=GBK
-ex_stage.v  working-tree-encoding=GBK
-hazard_unit.v  working-tree-encoding=GBK
-id_stage.v  working-tree-encoding=GBK
-mem_stage.v  working-tree-encoding=GBK
+cpu_top.v   working-tree-encoding=UTF-8
+ex_stage.v  working-tree-encoding=UTF-8
+hazard_unit.v  working-tree-encoding=UTF-8
+id_stage.v  working-tree-encoding=UTF-8
+mem_stage.v  working-tree-encoding=UTF-8
 


### PR DESCRIPTION
## Summary
- convert Verilog sources in `pipelineCPU.srcs/sources_1/new` to UTF-8
- adjust `.gitattributes` so these files are no longer checked out as GBK

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6866203674e48326900f541f60d51202