### PR TITLE
Add debug display on 7‑segment LEDs

### DIFF
--- a/pipelineCPU.srcs/sources_1/new/bin_to_bcd6.v
+++ b/pipelineCPU.srcs/sources_1/new/bin_to_bcd6.v
@@ -1,0 +1,26 @@
+module bin_to_bcd6(
+    input  wire [31:0] bin,
+    output reg  [3:0] d5,
+    output reg  [3:0] d4,
+    output reg  [3:0] d3,
+    output reg  [3:0] d2,
+    output reg  [3:0] d1,
+    output reg  [3:0] d0
+);
+    integer i;
+    reg [31:0] value;
+    reg [3:0] digit [0:5];
+    always @(*) begin
+        value = bin;
+        for(i=0;i<6;i=i+1) begin
+            digit[i] = value % 10;
+            value = value / 10;
+        end
+        d0 = digit[0];
+        d1 = digit[1];
+        d2 = digit[2];
+        d3 = digit[3];
+        d4 = digit[4];
+        d5 = digit[5];
+    end
+endmodule

--- a/pipelineCPU.srcs/sources_1/new/clock_divider.v
+++ b/pipelineCPU.srcs/sources_1/new/clock_divider.v
@@ -1,0 +1,14 @@
+module clock_divider #(parameter WIDTH = 24)(
+    input wire clk_in,
+    input wire reset,
+    output wire clk_out
+);
+    reg [WIDTH-1:0] counter;
+    always @(posedge clk_in or posedge reset) begin
+        if (reset)
+            counter <= 0;
+        else
+            counter <= counter + 1;
+    end
+    assign clk_out = counter[WIDTH-1];
+endmodule

--- a/pipelineCPU.srcs/sources_1/new/id_stage.v
+++ b/pipelineCPU.srcs/sources_1/new/id_stage.v
@@ -18,7 +18,9 @@ module id_stage(
     input  wire        wb_reg_write, // 写回使能信号
     input  wire        clk,
     input  wire        reset,
-    input  wire        hazard_stall  // 冒险暂停信号，高电平表示本周期ID阶段指令停顿，不更新输出
+    input  wire        hazard_stall, // 冒险暂停信号，高电平表示本周期ID阶段指令停顿，不更新输出
+    input  wire [4:0]  dbg_reg_idx,  // 调试读取的寄存器编号
+    output wire [31:0] dbg_reg_val
 );
     // 将指令字段拆分
     wire [6:0] opcode = instr[6:0];
@@ -38,6 +40,7 @@ module id_stage(
     // 异步读，同步写实现：
     assign rs1_val = regs[rs1_idx];
     assign rs2_val = regs[rs2_idx];
+    assign dbg_reg_val = regs[dbg_reg_idx];
     
     // 初始化寄存器（复位时）
     always @(posedge clk or posedge reset) begin

--- a/pipelineCPU.srcs/sources_1/new/seven_seg_driver.v
+++ b/pipelineCPU.srcs/sources_1/new/seven_seg_driver.v
@@ -1,0 +1,56 @@
+module seven_seg_driver(
+    input wire clk,
+    input wire reset,
+    input wire [3:0] d0,
+    input wire [3:0] d1,
+    input wire [3:0] d2,
+    input wire [3:0] d3,
+    input wire [3:0] d4,
+    input wire [3:0] d5,
+    input wire [3:0] d6,
+    input wire [3:0] d7,
+    output reg [7:0] seg,
+    output reg [7:0] an
+);
+    reg [2:0] scan;
+    reg [3:0] cur;
+    always @(posedge clk or posedge reset) begin
+        if (reset)
+            scan <= 0;
+        else
+            scan <= scan + 1;
+    end
+    always @(*) begin
+        case(scan)
+            3'd0: begin an = 8'b11111110; cur = d0; end
+            3'd1: begin an = 8'b11111101; cur = d1; end
+            3'd2: begin an = 8'b11111011; cur = d2; end
+            3'd3: begin an = 8'b11110111; cur = d3; end
+            3'd4: begin an = 8'b11101111; cur = d4; end
+            3'd5: begin an = 8'b11011111; cur = d5; end
+            3'd6: begin an = 8'b10111111; cur = d6; end
+            default: begin an = 8'b01111111; cur = d7; end
+        endcase
+    end
+    always @(*) begin
+        case(cur)
+            4'h0: seg = 8'b11000000;
+            4'h1: seg = 8'b11111001;
+            4'h2: seg = 8'b10100100;
+            4'h3: seg = 8'b10110000;
+            4'h4: seg = 8'b10011001;
+            4'h5: seg = 8'b10010010;
+            4'h6: seg = 8'b10000010;
+            4'h7: seg = 8'b11111000;
+            4'h8: seg = 8'b10000000;
+            4'h9: seg = 8'b10010000;
+            4'ha: seg = 8'b10001000;
+            4'hb: seg = 8'b10000011;
+            4'hc: seg = 8'b11000110;
+            4'hd: seg = 8'b10100001;
+            4'he: seg = 8'b10000110;
+            4'hf: seg = 8'b10001110;
+            default: seg = 8'b11111111;
+        endcase
+    end
+endmodule


### PR DESCRIPTION
## Summary
- add clock divider, binary-to-BCD, and seven-segment driver modules
- enhance `cpu_top` with debug clock control and display logic
- expose register readout port from `id_stage`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866226455448326ae932b0da73fa567